### PR TITLE
feat: repsect oid batch arguments

### DIFF
--- a/transfer/args.go
+++ b/transfer/args.go
@@ -19,12 +19,12 @@ const (
 )
 
 // ParseArgs parses the given args.
-func ParseArgs(lines []string) (map[string]string, error) {
-	args := make(map[string]string, 0)
-	for _, line := range lines {
+func ParseArgs(parts []string) (Args, error) {
+	args := make(Args, 0)
+	for _, line := range parts {
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid argument: %q", line)
+			continue
 		}
 		key, value := parts[0], parts[1]
 		args[key] = value
@@ -34,10 +34,18 @@ func ParseArgs(lines []string) (map[string]string, error) {
 }
 
 // ArgsToList converts the given args to a list.
-func ArgsToList(args map[string]string) []string {
+func ArgsToList(args Args) []string {
 	list := make([]string, 0)
 	for key, value := range args {
 		list = append(list, fmt.Sprintf("%s=%s", key, value))
 	}
 	return list
+}
+
+// Args is a key-value pair of arguments.
+type Args map[string]string
+
+// String returns the string representation of the arguments.
+func (a Args) String() string {
+	return strings.Join(ArgsToList(a), " ")
 }

--- a/transfer/args.go
+++ b/transfer/args.go
@@ -24,7 +24,7 @@ func ParseArgs(parts []string) (Args, error) {
 	for _, line := range parts {
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
-			continue
+			return nil, fmt.Errorf("invalid argument: %q", line)
 		}
 		key, value := parts[0], parts[1]
 		args[key] = value

--- a/transfer/backend.go
+++ b/transfer/backend.go
@@ -14,12 +14,12 @@ const (
 
 // Backend is a Git LFS backend.
 type Backend interface {
-	Batch(op string, pointers []Pointer, args map[string]string) ([]BatchItem, error)
-	StartUpload(oid string, r io.Reader, args map[string]string) (interface{}, error)
-	FinishUpload(state interface{}, args map[string]string) error
-	Verify(oid string, args map[string]string) (Status, error)
-	Download(oid string, args map[string]string) (fs.File, error)
-	LockBackend(args map[string]string) LockBackend
+	Batch(op string, pointers []BatchItem, args Args) ([]BatchItem, error)
+	StartUpload(oid string, r io.Reader, args Args) (interface{}, error)
+	FinishUpload(state interface{}, args Args) error
+	Verify(oid string, args Args) (Status, error)
+	Download(oid string, args Args) (fs.File, error)
+	LockBackend(args Args) LockBackend
 }
 
 // Lock is a Git LFS lock.

--- a/transfer/batch.go
+++ b/transfer/batch.go
@@ -3,6 +3,10 @@ package transfer
 // BatchItem is a Git LFS batch item.
 type BatchItem struct {
 	Pointer
-	Args    Args
+
+	// Present is used to determine the action to take for the batch item.
 	Present bool
+
+	// Args is an optional oid-line key-value pairs.
+	Args Args
 }

--- a/transfer/batch.go
+++ b/transfer/batch.go
@@ -3,5 +3,6 @@ package transfer
 // BatchItem is a Git LFS batch item.
 type BatchItem struct {
 	Pointer
+	Args    Args
 	Present bool
 }

--- a/transfer/oid.go
+++ b/transfer/oid.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"fmt"
 	"path"
 	"regexp"
 )
@@ -9,6 +10,11 @@ import (
 type Pointer struct {
 	Oid  string `json:"oid"`
 	Size int64  `json:"size"`
+}
+
+// String returns the string representation of the pointer.
+func (p Pointer) String() string {
+	return fmt.Sprintf("%s %d", p.Oid, p.Size)
 }
 
 var oidPattern = regexp.MustCompile(`^[a-f\d]{64}$`)

--- a/transfer/processor.go
+++ b/transfer/processor.go
@@ -61,22 +61,32 @@ func (p *Processor) ReadBatch(op string) ([]BatchItem, error) {
 	}
 	Logf("data: %d %v", len(data), data)
 	Logf("batch: %s args: %d %v data: %d %v", op, len(args), args, len(data), data)
-	items := make([]Pointer, 0)
+	items := make([]BatchItem, 0)
 	for _, line := range data {
 		if line == "" {
 			return nil, ErrInvalidPacket
 		}
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) != 2 || parts[1] == "" {
+		parts := strings.Split(line, " ")
+		if len(parts) < 2 || parts[1] == "" {
 			return nil, ErrParseError
 		}
 		size, err := strconv.ParseInt(parts[1], 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("%w: invalid integer, got: %q", ErrParseError, parts[1])
 		}
-		item := Pointer{
-			parts[0],
-			size,
+		var oidArgs Args
+		if len(parts) > 2 {
+			oidArgs, err = ParseArgs(parts[2:])
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s", ErrParseError, err)
+			}
+		}
+		item := BatchItem{
+			Pointer: Pointer{
+				Oid:  parts[0],
+				Size: size,
+			},
+			Args: oidArgs,
 		}
 		items = append(items, item)
 	}
@@ -101,7 +111,11 @@ func (p *Processor) BatchData(op string, presentAction string, missingAction str
 		if item.Present {
 			action = presentAction
 		}
-		oids = append(oids, fmt.Sprintf("%s %d %s", item.Oid, item.Size, action))
+		line := fmt.Sprintf("%s %s", item.Pointer, action)
+		if len(item.Args) > 0 {
+			line = fmt.Sprintf("%s %s", line, item.Args)
+		}
+		oids = append(oids, line)
 	}
 	return NewSuccessStatus(oids), nil
 }
@@ -117,7 +131,7 @@ func (p *Processor) DownloadBatch() (Status, error) {
 }
 
 // SizeFromArgs returns the size from the given args.
-func (Processor) SizeFromArgs(args map[string]string) (int64, error) {
+func SizeFromArgs(args Args) (int64, error) {
 	size, ok := args[SizeKey]
 	if !ok {
 		return 0, fmt.Errorf("missing required size header")
@@ -139,7 +153,7 @@ func (p *Processor) PutObject(oid string) (Status, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrParseError, err)
 	}
-	expectedSize, err := p.SizeFromArgs(args)
+	expectedSize, err := SizeFromArgs(args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Preserve oid batch arguments in requset/response per [specs](https://github.com/git-lfs/git-lfs/blob/main/docs/proposals/ssh_adapter.md#requests-to-transfer-objects)