### PR TITLE
fix: oid pointer relative path

### DIFF
--- a/transfer/oid.go
+++ b/transfer/oid.go
@@ -40,5 +40,5 @@ func (p Pointer) RelativePath() string {
 		return p.Oid
 	}
 
-	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid[4:])
+	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid)
 }


### PR DESCRIPTION
The [specs](https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md) define the relative path as lfs/objects/{OID[0:2]/OID[2:4]/OID}