### PR TITLE
Refactor backend interface

### DIFF
--- a/internal/local/backend.go
+++ b/internal/local/backend.go
@@ -58,7 +58,7 @@ func (l *LocalBackend) Batch(_ string, pointers []transfer.BatchItem, _ transfer
 
 // Download implements main.Backend. The returned reader must be closed by the
 // caller.
-func (l *LocalBackend) Download(oid string, _ transfer.Args) (fs.File, int64, error) {
+func (l *LocalBackend) Download(oid string, _ transfer.Args) (io.ReadCloser, int64, error) {
 	f, err := os.Open(oidExpectedPath(l.lfsPath, oid))
 	if err != nil {
 		return nil, 0, err

--- a/transfer/backend.go
+++ b/transfer/backend.go
@@ -14,8 +14,7 @@ const (
 // Backend is a Git LFS backend.
 type Backend interface {
 	Batch(op string, pointers []BatchItem, args Args) ([]BatchItem, error)
-	StartUpload(oid string, size int64, r io.Reader, args Args) (io.Closer, error)
-	FinishUpload(state io.Closer, args Args) error
+	Upload(oid string, size int64, r io.Reader, args Args) error
 	Verify(oid string, size int64, args Args) (Status, error)
 	Download(oid string, args Args) (io.ReadCloser, int64, error)
 	LockBackend(args Args) LockBackend

--- a/transfer/backend.go
+++ b/transfer/backend.go
@@ -2,7 +2,6 @@ package transfer
 
 import (
 	"io"
-	"io/fs"
 )
 
 const (
@@ -18,7 +17,7 @@ type Backend interface {
 	StartUpload(oid string, size int64, r io.Reader, args Args) (io.Closer, error)
 	FinishUpload(state io.Closer, args Args) error
 	Verify(oid string, size int64, args Args) (Status, error)
-	Download(oid string, args Args) (fs.File, int64, error)
+	Download(oid string, args Args) (io.ReadCloser, int64, error)
 	LockBackend(args Args) LockBackend
 }
 

--- a/transfer/backend.go
+++ b/transfer/backend.go
@@ -15,10 +15,10 @@ const (
 // Backend is a Git LFS backend.
 type Backend interface {
 	Batch(op string, pointers []BatchItem, args Args) ([]BatchItem, error)
-	StartUpload(oid string, r io.Reader, args Args) (io.Closer, error)
+	StartUpload(oid string, size int64, r io.Reader, args Args) (io.Closer, error)
 	FinishUpload(state io.Closer, args Args) error
-	Verify(oid string, args Args) (Status, error)
-	Download(oid string, args Args) (fs.File, error)
+	Verify(oid string, size int64, args Args) (Status, error)
+	Download(oid string, args Args) (fs.File, int64, error)
 	LockBackend(args Args) LockBackend
 }
 

--- a/transfer/hash.go
+++ b/transfer/hash.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"encoding/hex"
+	"fmt"
 	"hash"
 	"io"
 )
@@ -38,5 +39,41 @@ func (h *HashingReader) Read(p []byte) (int, error) {
 	n, err := h.r.Read(p)
 	h.size += int64(n)
 	h.hash.Write(p[:n])
+	return n, err
+}
+
+var _ io.Reader = (*VerifyingReader)(nil)
+
+// VerifyingReader is a reader that hashes the data it reads.
+// At EOF, it compares the OID and size with expected values and replaces EOF
+// with an error in the case of mismatch.
+type VerifyingReader struct {
+	r            *HashingReader
+	expectedOid  string
+	expectedSize int64
+}
+
+// NewVerifyingReader creates a new VerifyingReader.
+func NewVerifyingReader(r io.Reader, hash hash.Hash, oid string, size int64) *VerifyingReader {
+	return &VerifyingReader{
+		r:            NewHashingReader(r, hash),
+		expectedOid:  oid,
+		expectedSize: size,
+	}
+}
+
+// Read reads data from the underlying HashingReader.
+// At EOF, it compares results and returns error if OID or size mismatch
+func (v *VerifyingReader) Read(p []byte) (int, error) {
+	n, err := v.r.Read(p)
+	if err == io.EOF {
+		// stream consumed, now check for mismatch
+		if v.r.Size() != v.expectedSize {
+			err = fmt.Errorf("%w: invalid object size, expected %v, got %v", ErrCorruptData, v.expectedSize, v.r.Size())
+		}
+		if v.r.Oid() != v.expectedOid {
+			err = fmt.Errorf("%w: invalid object ID, expected %v, got %v", ErrCorruptData, v.expectedOid, v.r.Oid())
+		}
+	}
 	return n, err
 }


### PR DESCRIPTION
Hi charm.sh,

I was implementing the lfs-transfer protocol for gitea (https://github.com/go-gitea/gitea/issues/17554), and in the process I vendored your excellent transfer library from this repo. I made some changes for it to work better with Gitea's internal API, but I think those are improvements in the general sense too, hence I'm opening this PR.

All tests pass with the internal local backend in this repo.

Most of these changes are pretty self explanatory I hope, only the last commit is sort of contentious. In its defence, the old 2-stage Upload API was frankly horrific with the UploadState and whatnot. This works around that by using the same clever trick as `HashingReader`: a `VerifyingReader`. This makes it much simpler for backends, as handling corrupt input is just the same as handling errors from the reader. Also makes it very simple for backends that verify input themselves to just omit wrapping the reader.