### PR TITLE
fix: lock TOC/TOU condition

### DIFF
--- a/internal/local/lock_test.go
+++ b/internal/local/lock_test.go
@@ -1,0 +1,37 @@
+package local_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/charmbracelet/git-lfs-transfer/internal/local"
+	"github.com/charmbracelet/git-lfs-transfer/transfer"
+)
+
+func TestTakeLock(t *testing.T) {
+	tb := testing.TB(t)
+	tb.Helper()
+	path := filepath.Join(tb.TempDir(), "test_subject")
+	testfile, err := local.NewLockFile(path)
+	defer func() { _ = testfile.Close() }()
+	assert.Equal(t, err, nil)
+	assert.NotEqual(t, testfile, nil)
+}
+
+func TestMissLock(t *testing.T) {
+	tb := testing.TB(t)
+	tb.Helper()
+	path := filepath.Join(tb.TempDir(), "test_subject")
+	testfile, err := local.NewLockFile(path)
+	defer testfile.Close()
+	assert.Equal(t, err, nil)
+	assert.NotEqual(t, testfile, nil)
+	t2, e2 := local.NewLockFile(path)
+	if t2 != nil {
+		defer t2.Close()
+	}
+	assert.Equal(t, e2, transfer.ErrConflict)
+	assert.NotEqual(t, t2, nil)
+}


### PR DESCRIPTION
Taking the lock is one (atomic) filesystem operation. This prevents race conditions when another process creates the lock after os.Stat() and before os.Create(). Now, If we get the lock, we have the lock.

There is a condition where we may miss the lock, but it is released before we open for information purposes. This still counts as missing the lock.